### PR TITLE
fix: extract and validate identifiers with early null filtering

### DIFF
--- a/fhirbuild/csvtofhir.py
+++ b/fhirbuild/csvtofhir.py
@@ -307,7 +307,7 @@ def extract_and_resolve_identifiers(row: dict, prefix: str, mainidc: str) -> tup
     Raises:
         ValueError: If the prefix is not 'sidc_' or 'pidc_'
         ValueError: If no identifiers with the specified prefix are found in the row.
-        ValueError: If the mainidc specified does not have a corresponding column or the value is nullish in the row
+        ValueError: If the main identifier code specified but does not have a corresponding column or the value is nullish in the row
     """
     
 


### PR DESCRIPTION
## Fix: Identifier extraction with early validation

### Problem

Nullish values (empty strings, NULL, None) from CSV data were passed through
the identifier extraction unfiltered and result in errors while create fhir ressources for empty values 

### Changes
- new function  `extract_and_resolve_identifiers`
- **Early nullish filtering:** `extract_and_resolve_identifiers` now filters nullish
  values immediately during collection, so only valid identifiers are returned.
- **Fixed mainidc priority:** Clear resolution order:
  1. Explicitly passed argument
  2. Auto-detect if only one identifier exists
  3. Fallback to `mainidc` column in CSV row
- **Extended return type:** Function returns `(identifiers, mainidc)` tuple
  so the caller doesn't need to resolve mainidc separately.

### Impact

- Callers that previously resolved mainidc after calling this function can
  remove that logic.
- The FHIR builder receives only pre-validated identifiers and no longer needs
  its own null checks.