### PR TITLE
Fix/dig use

### DIFF
--- a/fhirbuild/csvtofhir.py
+++ b/fhirbuild/csvtofhir.py
@@ -129,8 +129,8 @@ def row_to_sample(row:dict, mainidc:str=None) -> dict:
     # convert yxpos to xpos and ypos if given
     xpos = intornone(row['ypos'])
     ypos = intornone(row['ypos'])
-    if dig(row, "yxpos") is not None:
-        yxpos = dig(row, "yxpos")
+    if row.get("yxpos") is not None:
+        yxpos = row.get("yxpos")
         (xpos, ypos) = a01toxy(yxpos)
         
     # make a sample instance from the row

--- a/fhirbuild/csvtofhir.py
+++ b/fhirbuild/csvtofhir.py
@@ -13,8 +13,9 @@ import os
 import re
 import math
 import fhirbuild.help as fbh
-from fhirbuild.help import intornone, is_nullish
+from fhirbuild.help import intornone, is_nullish, letter_index_value
 from dbcq import dbcq
+from typing import Optional 
 
 def csv_to_samples(reader: csv.DictReader, mainidc:str=None):
     """csv_to_samples turns a csv file into a list of Sample instances. mainidc can be given as argument or csv column. fhirids are taken if given, but not generated."""
@@ -131,7 +132,7 @@ def row_to_sample(row:dict, mainidc:str=None) -> dict:
     ypos = intornone(row['ypos'])
     if row.get("yxpos") is not None:
         yxpos = row.get("yxpos")
-        (xpos, ypos) = a01toxy(yxpos)
+        (xpos, ypos) = parse_tube_position(yxpos)
         
     # make a sample instance from the row
     sample = Sample(
@@ -156,18 +157,32 @@ def row_to_sample(row:dict, mainidc:str=None) -> dict:
     # return
     return sample
 
-def a01toxy(yxpos:str) -> (int, int):
-    """a01toxy converts an A01 position (y: A, x: 01) to a 0?1?-indexed (x,y) position."""
-    
-    # y is the letter
-    ystr = yxpos[0:1]
-    atoy = { "A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6, "G": 7, "H": 8 }
-    y = atoy[ystr]
-    
-    # x are the digits
-    x = int(yxpos[1:3])
+def parse_tube_position(tube_position: Optional[str | None]) -> tuple[int, int]:
+    """Converts a tube position (e.g. "A05") to a 1-indexed (x, y) position.
+        Args:
+            tube_position (str): The tube position in the format of a row (Y) letter followed by a column (X) number (e.g., "A01").
+        Returns:
+            tuple[int, int]: A 1-indexed (x, y) tuple where the number is the x-position and the letter is the y-position,
+                e.g. "A05" becomes (5, 1).
+    """
 
-    return (x, y)
+    if tube_position is None or tube_position == "":
+        raise ValueError("tube_position must not be None or empty")
+
+    y_pos_letter = tube_position[0:1]
+    x_pos = tube_position[1:]
+    
+    if not y_pos_letter.isalpha():
+        raise ValueError(f"invalid y-position {tube_position}: y needs to be a letter.")
+    
+    if not x_pos.isdigit():
+        raise ValueError(f"invalid x-position {tube_position}: x needs to be a number.")
+
+    y_pos = letter_index_value(y_pos_letter)
+    
+    x_pos = int(x_pos)
+
+    return (x_pos, y_pos)
 
 def row_to_patient_fhir(row:dict, mainidc:str=None):
     """row_to_patient_fhir turns a csv row to a patient fhir entry. it lets update_with_overwrite be set for each row."""

--- a/fhirbuild/csvtofhir.py
+++ b/fhirbuild/csvtofhir.py
@@ -128,7 +128,7 @@ def row_to_sample(row:dict, mainidc:str=None) -> dict:
         patids.append(Identifier(code=type, id=value))
 
     # convert yxpos to xpos and ypos if given
-    xpos = intornone(row['ypos'])
+    xpos = intornone(row['xpos'])
     ypos = intornone(row['ypos'])
     if row.get("yxpos") is not None:
         yxpos = row.get("yxpos")

--- a/fhirbuild/help.py
+++ b/fhirbuild/help.py
@@ -82,3 +82,9 @@ def open_csv_file(filename, delimiter=";", encoding="utf-8"):
         print(f"Error opening file {filename}: {e}")
         sys.exit(1)
 
+def letter_index_value(letter: str) -> int:
+    if not letter.isalpha():
+        raise ValueError(f"Input must be a single letter, got '{letter}'")
+    numeric_value = ord(letter.upper()) - ord('A') + 1
+    return numeric_value
+

--- a/fhirbuild/tests/test_csvtofhir.py
+++ b/fhirbuild/tests/test_csvtofhir.py
@@ -1,0 +1,21 @@
+import pytest 
+import fhirbuild.csvtofhir as ctf
+import fhirbuild.help as fbh
+
+def test_parse_valid_tube_positions():
+    assert ctf.parse_tube_position("A01") == (1, 1)
+    assert ctf.parse_tube_position("B02") == (2, 2)
+    assert ctf.parse_tube_position("C03") == (3, 3)
+    assert ctf.parse_tube_position("D10") == (10, 4)
+
+def test_parse_invalid_tube_positions():
+    with pytest.raises(ValueError):
+        ctf.parse_tube_position("")   
+
+    with pytest.raises(ValueError):
+        ctf.parse_tube_position("AA1")   
+
+    with pytest.raises(ValueError):
+        ctf.parse_tube_position("1A")   
+
+    

--- a/fhirbuild/tests/test_help.py
+++ b/fhirbuild/tests/test_help.py
@@ -1,0 +1,15 @@
+import pytest
+
+from fhirbuild.help import letter_index_value
+
+def test_valid_letter_index_value():
+    assert letter_index_value('A') == 1
+    assert letter_index_value('B') == 2
+    assert letter_index_value('Z') == 26
+    assert letter_index_value('a') == 1
+    assert letter_index_value('b') == 2
+    assert letter_index_value('z') == 26
+
+def test_invalid_letter_index_value():
+    with pytest.raises(ValueError):
+        letter_index_value('1')


### PR DESCRIPTION
This pull request refactors and improves the handling of tube position parsing in the `fhirbuild` package, making the code more robust and testable. 
The main changes include replacing the old `a01toxy` function with a new, more clearly named and validated `parse_tube_position` function, introducing a utility for converting letters to numeric indices, and adding comprehensive tests for these new utilities.

**Tube position parsing improvements:**

* Replaced the `a01toxy` function with `parse_tube_position`, which now includes input validation and clearer documentation. The new function converts tube positions like "A01" into (x, y) tuples and raises errors for invalid inputs. 
* Updated the logic in `row_to_sample` to use the new `parse_tube_position` function for converting tube positions, improving reliability and readability.

**Tube postion fix x-position
* Wrong column was used to get the x-position, instead of `xpos = intornone(row['ypos'])` `xpos = intornone(row['xpos'])` is used 

**Utility function addition:**

* Added `letter_index_value` to convert a single letter to its corresponding 1-based index (e.g., 'A' → 1), used in tube position parsing. 
* Updated imports to use the new utility function. 

**Testing enhancements:**

* Added new tests for `parse_tube_position`, covering both valid and invalid cases.
* Added tests for `letter_index_value`, ensuring correct conversion and proper error handling. 